### PR TITLE
Raspi Mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,16 @@ Dieser DR!FT Racingserver verfolgt zwei Ziele: Zum einen als Prototyp um die DR!
 
 Achtung: Dieser Server ist nicht dazu geeignet, ihn offen ins Internet zu stellen. Die generierte Webseite hat z.B. keinerlei Sicherheitsmaßnahmen wie eine Benutzerverwaltung oder Passwortschutz, d.h. jeder der die Adresse der Webseite kennt kann dort Rennen anlegen, löschen etc.. Benutzt ihn also besser nur lokal und mit Leuten, die da keinen Mist mit machen. Wir werden in Zukunft sicherlich noch bessere Racingserver sehen, die dann im Internet laufen und auf denen jeder ohne Installation bequem selbst seine Rennen auf machen kann, aber das wird noch eine Weile dauern. Dieser Racingserver dient erst mal der schnellen Entwicklung einer soliden Basis. Wenn du mehr zur Entwicklung etc. wissen willst, schau mal ins Kapitel  [DR!FT Community API](#drift-community-api)
 
+# Vorraussetzungen
+- Basis ist Pi-OS 64Bit bullseye (jippieh, es geht sogar ohne das fette Ubuntu/Debian sondern mit dem entschlackten und schnell bootenden System)
+- Voraussetzung ist ein Pi4. Eventuell kann man es auch auf dem Pi3 und 2w laufen lassen, müsste man testen (ich selbst hab keinen). Pi2 und weniger geht definitiv nicht, sofern man an der MongoDB festhält.
+
 # Installation
-Zunächst musst du die Software "Docker" installieren. Diese gibt es für Windows, iOS und Linux und eine bequeme Desktop-Version bekommst du hier:
+- Zunächst musst du die Software "Docker" installieren. 
 
-https://www.docker.com/products/docker-desktop
+Auf dem Raspberry funktioniert das so:
+https://www.blog.berrybase.de/blog/2022/02/23/docker-auf-dem-raspberry-pi-basics/ 
 
-Unter Windows musst du noch das Kernel-Upgrade für WSL2 installieren:
-https://wslstorestorage.blob.core.windows.net/wslblob/wsl_update_x64.msi
-
-Und Hyper-V sowie Containers in den Windows Einstellungen aktivieren (geht wohl auch ohne bei Windows Home):
-https://www.c-sharpcorner.com/article/how-to-install-docker-desktop-and-troubleshoot-issues-in-windows-machine/
 
 Um zu testen, dass du Docker richtig installiert hast, öffne eine Konsole (Unter Windows geht das über "Shift+Rechtsklick"->"PowerShell Fenster hier öffnen") und tippe den folgenden Befehl, gefolgt von "Enter":
 
@@ -31,9 +31,10 @@ Um zu testen, dass du Docker richtig installiert hast, öffne eine Konsole (Unte
 
 Docker dient als Ausführungsumgebung für die Server, diese laufen als virtuelle Maschinen in Docker, so dass wir keine weitere Software direkt auf deinem PC installieren müssen.
 
-Als Zweites musst du dieses Projekt hier herunter laden. Dazu kannst du oben rechts auf den grünen "Code" Button klicken und wählst "Download ZIP" aus. Das Verzeichnis musst du anschließend noch entpacken, die meisten Computer haben dafür schon Software installiert, falls nicht, empfehle ich dafür: [7Zip - Download](https://www.7-zip.de/).
+Als Zweites musst du dieses Projekt hier herunter laden. installierst du git auf dem pi und ziehst es mit 
+> git clone https://github.com/Fooxbox/driftapi
 
-Jetzt folgt der letzte Schritt: Öffne ein Konsolenfenster im Projektordner ("Shift+Rechtsklick" irgendwo im Ordner->PowerShell-Fenster hier öffnen) und gebe den folgenden Befehl ein:
+Jetzt folgt der letzte Schritt: Öffne ein Konsolenfenster (oder via SSH) im Projektordner (also "driftapi") und gebe den folgenden Befehl ein:
 
 >docker compose --profile racedisplay up --build
 
@@ -68,7 +69,7 @@ Deinstallation: Für eine Deinstalation löscht ihr einfach den heruntergeladene
 # Bedienung
 Öffne einen Browser deiner Wahl (Chrome und Firefox sind getestet, Safari macht vielleicht Probleme) und gib die folgende Adresse ein:
 
->127.0.0.1:8080
+> [IP des Pi]:8080
 
 Du solltest ins Hauptmenü des Servers kommen, von wo aus du Rennen anlegen (Create New Game) oder zuvor angelegte Rennen aufrufen (Show Game) kannst. Hinweis: Sobald ein Rennen angelegt wurde, nimmt der Server Daten von der App entgegen, unabhängig davon, ob du das Browserfenster offen lässt oder welches Rennen du gerade anzeigst. Du kannst also ruhig mehrere Rennen erstellen die gleichzeitig von Spielern genutzt werden.
 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,15 @@ Um zu testen, dass du Docker richtig installiert hast, öffne eine Konsole (Unte
 
 Docker dient als Ausführungsumgebung für die Server, diese laufen als virtuelle Maschinen in Docker, so dass wir keine weitere Software direkt auf deinem PC installieren müssen.
 
-Als Zweites musst du dieses Projekt hier herunter laden. installierst du git auf dem pi und ziehst es mit 
+Im zweiten Schritt musst du die Dateien auf den Pi bringen:
+Du kannst git auf dem Pi installieren und dieses Projekt herunter laden mit dem Befehl: 
 > git clone https://github.com/Fooxbox/driftapi
 
-Jetzt folgt der letzte Schritt: Öffne ein Konsolenfenster (oder via SSH) im Projektordner (also "driftapi") und gebe den folgenden Befehl ein:
+Oder du lädst die Struktur manuell herunter und legst sie auf die SD-Karte des Pi ab
+
+
+
+Jetzt folgt der letzte Schritt: Öffne ein Konsolenfenster (oder via SSH) im Projektordner (der sollte "driftapi" heissen) und gebe den folgenden Befehl ein:
 
 >docker compose --profile racedisplay up --build
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - 8001:8001
 
   driftapi-db:
-    image: mongo
+    image: mongo:bionic
     ports:
       - 27018:27017
 

--- a/driftapi/Dockerfile
+++ b/driftapi/Dockerfile
@@ -1,5 +1,5 @@
 # Generic Poetry Build Stage
-FROM python:3.9.7-slim as builder
+FROM arm64v8/python:3.10.4-bullseye as builder
 RUN pip3 install "poetry==1.1.11"
 
 # copy and build service to Wheel
@@ -9,7 +9,8 @@ COPY ./driftapi ./driftapi
 RUN poetry build
 
 # build the actual image with just Python + PIP
-FROM tiangolo/uvicorn-gunicorn:python3.8-slim
+# FROM tiangolo/uvicorn-gunicorn:python3.8
+FROM tedivm/uvicorn-gunicorn:latest
 COPY --from=builder /app/dist/driftapi*.whl ./whl/
 RUN pip3 install ./whl/*
 

--- a/streamlit/Dockerfile
+++ b/streamlit/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.12
+FROM arm64v8/python:3.10.4-bullseye
 WORKDIR /app
 COPY . .
 RUN pip install -r requirements.txt

--- a/streamlit/app.py
+++ b/streamlit/app.py
@@ -20,7 +20,7 @@ if __name__ == '__main__':
     _max_width_(90)
     app = MultiPage()
     # Title of the main page
-    st.title("DR!FT Racingserver Prototype")
+    st.title("DR!FT Racingserver Raspberry Mod")
 
     # Add all your applications (pages) here
     app.add_page("main_page", mainpage.app)


### PR DESCRIPTION
Hi Christian,
ich habe mal einen Fork (incl kurzes Update der Anleitung) angelegt, um die Anpassungen an den Raspberry verfügbar zu machen. Leider habe ich keine Möglichkeit gefunden, um die Anpassungen in der docker-compose.yml und den beiden Dockerfiles so zu gestalten, dass man das gleiche Set an Dateien für x86 und ARM Architektur benutzen kann. Vielleicht fällt dir etwas ein, wie man sinnvoll beides zusammen in den main fork bekommt?

Wie du im compare siehst, konnte ich die Portierung alleine dadurch umsetzen, indem ich andere Raspi-taugliche Pakete anziehe. Das Paket von Tedivm schaut recht sauber aus, er hat es auch als Pull Request bei tiangolo angemeldet. Die restlichen sind alles Standards. Leider hatte ich mit den Slim-Versionen der Python-Pakete keinen Erfolg ... da fehlt dann immer irgendetwas und der Build geht auf Fehler. Also nicht grade eine schlanke Lösung, aber es funktioniert wenigstens.

Grüße,
Markus